### PR TITLE
Disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Require descriptions on issues. Applies org wide.

This will ensure at least base level context is available and help protect against very vague issues collecting on trackers, as it happening currently. No specific structure is enforced (e.g. [forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)), purely requires the presence of a description.