### PR TITLE
fix(build-dev-image): add some args for non-standard options

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -4,14 +4,17 @@ on:
   workflow_call:
     inputs:
       dockerfile:
+        description: "Dockerfile that specifies the image"
         default: Dockerfile
         type: string
         required: false
       crystal_version:
+        description: "Crystal compiler version to build the image against"
         default: 1.3.2
         required: false
         type: string
       target:
+        description: "An optional target for repositories that specify multiple services"
         default: ""
         type: string
         required: false

--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         push: true
         file: ${{ inputs.dockerfile }}
-        tags: ghcr.io/${{ steps.name.outputs.image }}:${{ steps.name.outputs.tag }}
+        tags: ghcr.io/${{ inputs.target != '' &&  inputs.target || steps.name.outputs.image }}:${{ steps.name.outputs.tag }}
         build-args: |
           CRYSTAL_VERSION=${{ inputs.crystal_version }}
           TARGET=${{ inputs.target != '' &&  inputs.target || steps.name.outputs.image }}

--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -1,14 +1,27 @@
-name: Build Dev Image
+name: Development Image
 
 on:
   workflow_call:
+    inputs:
+      dockerfile:
+        default: Dockerfile
+        type: string
+        required: false
+      crystal_version:
+        default: 1.3.2
+        required: false
+        type: string
+      target:
+        default: ""
+        type: string
+        required: false
     secrets:
       GHCR_PAT:
         description: Token to push to Github Container Registry
         required: true
 
 jobs:
-  build-image:
+  build:
     runs-on: ubuntu-latest
     name: Build
     steps:
@@ -47,7 +60,11 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         push: true
+        file: ${{ inputs.dockerfile }}
         tags: ghcr.io/${{ steps.name.outputs.image }}:${{ steps.name.outputs.tag }}
+        build-args: |
+          CRYSTAL_VERSION=${{ inputs.crystal_version }}
+          TARGET=${{ inputs.target != '' &&  inputs.target || steps.name.outputs.image }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache
         labels: |


### PR DESCRIPTION
Adds...
- `crystal_version`, with a sane default
- `target`, with default to the name of the repository
- `dockerfile`, for repositories that deviate from the `Dockerfile` standard