### PR TITLE
fix(docker): upgrade apk to support version of APKINDEX.tar.gz in edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ ARG PLACE_COMMIT="DEV"
 
 # - Add trusted CAs for communicating with external services
 # - Add watchexec for running tests on change
-RUN apk add --no-cache \
+RUN apk upgrade --no-cache apk \
+    && \
+    apk add --no-cache \
         bash \
         ca-certificates \
         curl \


### PR DESCRIPTION
Fixes an issue with the format of APKINDEX.tar.gz in edge not being supported by the version of apk installed in alpine 3.12.9 

**Describe the bug**

```
The command 'apk add --no-cache         bash         ca-certificates         curl         iputils         libelf         libssh2-static         yaml-static     &&     apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing         watchexec     &&     update-ca-certificates' returned a non-zero code: 1
Service 'api' failed to build : Build failed
Error: Process completed with exit code 1.
```

**Your environment**
```
# cat /etc/alpine-release 
3.12.9/
```

**To Reproduce**
```
Try to install watchexec from edge
➜ 8:27AM ~ docker run -it --rm crystallang/crystal:1.3.2-alpine /bin/sh/
# cat /etc/alpine-release 
3.12.9/
# apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing watchexec
fetch http://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gzERROR: FDB format error (line 34281)
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gzfetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:  watchexec (no such package):
    required by: world[watchexec]
```

