### PR TITLE
feat(publish-crystal-docs): add action to generate crystal docs

### DIFF
--- a/.github/workflows/publish-crystal-docs.yml
+++ b/.github/workflows/publish-crystal-docs.yml
@@ -1,0 +1,22 @@
+name: "Crystal Docs"
+on:
+  workflow_call:
+
+jobs:
+  publish:
+    if: contains(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    container: crystallang/crystal
+    steps:
+      - uses: actions/checkout@v2
+      - run: shards install --ignore-crystal-version
+      - name: Run `crystal docs`
+        run: crystal docs
+      - name: Publish to GitHub Pages
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: docs
+          build_dir: docs
+          commit_message: "docs: update for ${{ github.ref }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A simple action to build and publish crystal docs.

Assumes gh pages have been set up for the `docs` branch.

A future extension could be varying which branch to publish to.

It would be ideal if this action could handle the initial set-up of gh pages.