### PR TITLE
feat(containerised-test): TODOs → GitHub Issues

### DIFF
--- a/.github/workflows/containerised-test.yml
+++ b/.github/workflows/containerised-test.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: caspiano/todo-to-issue-action@feat/crystal
+        with:
+          AUTO_ASSIGN: true # Assign issue to whoever wrote the todo
 
   test:
     name: "${{ !matrix.stable && '🚧 ' || '' }}crystal: ${{ matrix.crystal }}, MT: ${{ matrix.MT && '☑' || '☐' }}, canary: ${{ matrix.canary && '☑' || '☐' }}"

--- a/.github/workflows/containerised-test.yml
+++ b/.github/workflows/containerised-test.yml
@@ -6,8 +6,20 @@ on:
         description: 'Whether or not to cache shards'
         type: boolean
         default: true
+      todo_issues:
+        descripton: 'Whether or not to convert found TODOs to issues'
+        type: boolean
+        default: false
 
 jobs:
+  todo-issues:
+    if: ${{ inputs.todo_issues }}
+    name: TODOs → GitHub Issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: caspiano/todo-to-issue-action@feat/crystal
+
   test:
     name: "${{ !matrix.stable && '🚧 ' || '' }}crystal: ${{ matrix.crystal }}, MT: ${{ matrix.MT && '☑' || '☐' }}, canary: ${{ matrix.canary && '☑' || '☐' }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/gh-action-style.yml
+++ b/.github/workflows/gh-action-style.yml
@@ -1,0 +1,19 @@
+name: GH Action Style
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: actionlint
+        uses: reviewdog/action-actionlint@v1.14.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          level: info
+          reporter: github-pr-review
+          filter_mode: nofilter

--- a/.github/workflows/script-style.yml
+++ b/.github/workflows/script-style.yml
@@ -1,0 +1,15 @@
+name: Script Style
+on:
+  push:
+    paths:
+      - '*/**/*.(sh|bash)'
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          fail_on_error: true
+          reporter: github-pr-review


### PR DESCRIPTION
**Description of the change**

Converts TODOs found inline in a codebase to GitHub issues.

**Benefits**

Extracts TODOs that can wither in the codebase without discussion into a more readily discussed and estimated Issue.
The original author of the TODO will be assigned, so they can add additional context, implement, or remove the TODO.

When the TODO is removed, the corresponding issue should be closed automatically.

**Possible drawbacks**

TODOs are scattered across our services, with around ~40 open TODOs through the codebase.
This will produce a lot of noise on our issue tracker.