### PR TITLE
ci(build-spec-containers): only run on main branch

### DIFF
--- a/.github/workflows/build-spec-containers.yml
+++ b/.github/workflows/build-spec-containers.yml
@@ -2,6 +2,8 @@ name: Build Spec Containers
 
 on:
   push:
+    branches:
+      - main
     paths:
       - .github/workflows/build-spec-containers.yml
       - Dockerfile


### PR DESCRIPTION
**Description of the change**

Prevents secondary branches from triggering build workflow