### PR TITLE
fix(build-spec-containers): publish when branch is main

### DIFF
--- a/.github/workflows/build-spec-containers.yml
+++ b/.github/workflows/build-spec-containers.yml
@@ -2,8 +2,6 @@ name: Build Spec Containers
 
 on:
   push:
-    branches:
-      - main
     paths:
       - .github/workflows/build-spec-containers.yml
       - Dockerfile
@@ -54,6 +52,7 @@ jobs:
 
   publish:
     needs: build
+    if: contains(github.ref, 'refs/heads/main')
     runs-on: ubuntu-latest
     name: Publish
     steps:


### PR DESCRIPTION
**Description of the change**

Triggering build by branch was a bad idea because we miss when changes can break builds.
This PR skips the `publish` job if the branch is _not_ `main`

**Benefits**

Prevents `main` build from breaking