### PR TITLE
ci(autolabel-pr): use conventional commits to label

### DIFF
--- a/.github/workflows/autolabel-pr.yml
+++ b/.github/workflows/autolabel-pr.yml
@@ -13,7 +13,7 @@ jobs:
             {
               "build": "type: maintenance",
               "chore": "type: chore",
-              "ci": "type: devops",
+              "ci": "focus: devops",
               "docs": "type: documentation",
               "feat": "type: enhancement",
               "fix": "type: bug",

--- a/.github/workflows/autolabel-pr.yml
+++ b/.github/workflows/autolabel-pr.yml
@@ -1,0 +1,21 @@
+name: Conventional Labels
+
+on:
+  workflow_call:
+
+jobs:
+  label:
+    name: Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1
+        with:
+          type_labels:
+            build: 'type: maintenance'
+            chore: 'type: chore'
+            ci: 'type: devops'
+            docs: 'type: documentation'
+            feat: 'type: enhancement'
+            fix: 'type: bug'
+            refactor: 'type: refactor'
+          ignored_types: []

--- a/.github/workflows/autolabel-pr.yml
+++ b/.github/workflows/autolabel-pr.yml
@@ -1,5 +1,4 @@
 name: Conventional Labels
-
 on:
   workflow_call:
 
@@ -8,7 +7,7 @@ jobs:
     name: Label
     runs-on: ubuntu-latest
     steps:
-      - uses: bcoe/conventional-release-labels@v1
+      - uses: bcoe/conventional-release-labels@v1.3.0
         with:
           type_labels:
             build: 'type: maintenance'

--- a/.github/workflows/autolabel-pr.yml
+++ b/.github/workflows/autolabel-pr.yml
@@ -9,12 +9,14 @@ jobs:
     steps:
       - uses: bcoe/conventional-release-labels@v1.3.0
         with:
-          type_labels:
-            build: 'type: maintenance'
-            chore: 'type: chore'
-            ci: 'type: devops'
-            docs: 'type: documentation'
-            feat: 'type: enhancement'
-            fix: 'type: bug'
-            refactor: 'type: refactor'
-          ignored_types: []
+          type_labels: |
+            {
+              "build": "type: maintenance",
+              "chore": "type: chore",
+              "ci": "type: devops",
+              "docs": "type: documentation",
+              "feat": "type: enhancement",
+              "fix": "type: bug",
+              "refactor": "type: refactor"
+            }
+          ignored_types: '[]'


### PR DESCRIPTION
**Description of the change**

Small time-saver for adding github labels to PRs

**Benefits**

Hopefully no unlabelled PRs!
This means it's easier to identify what changes are occurring through our tracking software.

**Possible drawbacks**

Another github action to maintain.
